### PR TITLE
improve best practices in unit tests

### DIFF
--- a/src/components/layout/HeaderMainTitle/HeaderMainTitle.test.js
+++ b/src/components/layout/HeaderMainTitle/HeaderMainTitle.test.js
@@ -8,7 +8,9 @@ describe("<HeaderMainTitle />", () => {
   test("it should mount and contain main title", () => {
     renderWithRoute(<HeaderMainTitle />);
 
-    expect(screen.getByText("NDC")).toBeInTheDocument();
-    expect(screen.getByText("National Data Catalog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /ndc/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /national data catalog/i })
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/layout/HeaderNavigation/HeaderNavigation.test.js
+++ b/src/components/layout/HeaderNavigation/HeaderNavigation.test.js
@@ -8,7 +8,9 @@ describe("<HeaderNavigation />", () => {
   test("it should mount with main title", () => {
     renderWithRoute(<HeaderNavigation />);
 
-    const navigation = screen.getByText("National Data Catalog");
+    const navigation = screen.getByRole("heading", {
+      name: /national data catalog/i,
+    });
 
     expect(navigation).toBeInTheDocument();
   });
@@ -16,7 +18,7 @@ describe("<HeaderNavigation />", () => {
   test("it should mount with categories", () => {
     renderWithRoute(<HeaderNavigation />);
 
-    const categories = screen.getByText("Categorie");
+    const categories = screen.getByText(/categorie/i);
 
     expect(categories).toBeInTheDocument();
   });

--- a/src/components/layout/HeaderSlim/HeaderSlim.test.js
+++ b/src/components/layout/HeaderSlim/HeaderSlim.test.js
@@ -7,7 +7,7 @@ describe("<HeaderSlim />", () => {
   test("it should mount", () => {
     render(<HeaderSlim />);
 
-    const header = screen.getByText("Team Digitale");
+    const header = screen.getByRole("link", { name: /team digitale/i });
 
     expect(header).toBeInTheDocument();
   });
@@ -15,7 +15,9 @@ describe("<HeaderSlim />", () => {
   test("it HeaderSlim point to Team Digitale's homepage", () => {
     render(<HeaderSlim />);
 
-    const anchor = screen.getByText("Team Digitale").closest("a");
+    const anchor = screen
+      .getByRole("link", { name: /team digitale/i })
+      .closest("a");
 
     expect(anchor).toBeInTheDocument();
     expect(anchor).toHaveAttribute("href", "https://teamdigitale.governo.it/");

--- a/src/components/search/SearchPage/SearchPage.test.js
+++ b/src/components/search/SearchPage/SearchPage.test.js
@@ -22,7 +22,7 @@ describe("<SearchPage />", () => {
   });
 
   test("it should mount", async () => {
-    renderWithRoute(<SearchPage />, "");
+    renderWithRoute(<SearchPage />);
 
     const vocabs = await screen.findByTestId("SearchPage");
 

--- a/src/components/search/SearchPage/SearchPage.test.js
+++ b/src/components/search/SearchPage/SearchPage.test.js
@@ -32,9 +32,11 @@ describe("<SearchPage />", () => {
   test("it should search with appropriate filters", async () => {
     renderWithRoute(<SearchPage />, "/search?type=vocabulary&pattern=abc");
 
-    expect(search).toHaveBeenCalledWith({
-      type: AT_VOCABULARY,
-      pattern: "abc",
+    await waitFor(() => {
+      expect(search).toHaveBeenCalledWith({
+        type: AT_VOCABULARY,
+        pattern: "abc",
+      });
     });
   });
 
@@ -55,9 +57,9 @@ describe("<SearchPage />", () => {
     test("it should not show any type filter", async () => {
       renderWithRoute(<SearchPage />, "/search");
 
-      const filter = screen.queryByText("Ontologia");
-
-      expect(filter).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(screen.queryByText("Ontologia")).not.toBeInTheDocument()
+      );
     });
   });
 

--- a/src/components/search/SearchPage/SearchPage.test.js
+++ b/src/components/search/SearchPage/SearchPage.test.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { act, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
 import "@testing-library/jest-dom/extend-expect";
 import SearchPage from "./SearchPage";
 import { search } from "../../../services/searchService";
@@ -21,19 +22,15 @@ describe("<SearchPage />", () => {
   });
 
   test("it should mount", async () => {
-    await act(async () => {
-      renderWithRoute(<SearchPage />, "");
-    });
+    renderWithRoute(<SearchPage />, "");
 
-    const vocabs = screen.getByTestId("SearchPage");
+    const vocabs = await screen.findByTestId("SearchPage");
 
     expect(vocabs).toBeInTheDocument();
   });
 
   test("it should search with appropriate filters", async () => {
-    await act(async () => {
-      renderWithRoute(<SearchPage />, "/search?type=vocabulary&pattern=abc");
-    });
+    renderWithRoute(<SearchPage />, "/search?type=vocabulary&pattern=abc");
 
     expect(search).toHaveBeenCalledWith({
       type: AT_VOCABULARY,
@@ -48,19 +45,15 @@ describe("<SearchPage />", () => {
     });
 
     test("it should show selected filter", async () => {
-      await act(async () => {
-        renderWithRoute(<SearchPage />, "/search?type=ontology");
-      });
+      renderWithRoute(<SearchPage />, "/search?type=ontology");
 
-      const filter = screen.getByText("Ontologia");
+      const filter = await screen.findByText("Ontologia");
 
       expect(filter).toBeInTheDocument();
     });
 
     test("it should not show any type filter", async () => {
-      await act(async () => {
-        renderWithRoute(<SearchPage />, "/search");
-      });
+      renderWithRoute(<SearchPage />, "/search");
 
       const filter = screen.queryByText("Ontologia");
 
@@ -97,13 +90,10 @@ describe("<SearchPage />", () => {
     });
 
     test("it show propagate items to result component", async () => {
-      await act(async () => {
-        renderWithRoute(<SearchPage />, "/search?type=vocabulary");
+      renderWithRoute(<SearchPage />, "/search?type=vocabulary");
+      simulateVocabDataLoaded();
 
-        simulateVocabDataLoaded();
-      });
-
-      expect(SearchResults).toHaveBeenCalled();
+      await waitFor(() => expect(SearchResults).toHaveBeenCalled());
       expect(SearchResults).toHaveBeenCalledWith({ items: someVocabs }, {});
     });
   });

--- a/src/components/semantic-assets/VocabPage/VocabPage.test.js
+++ b/src/components/semantic-assets/VocabPage/VocabPage.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import "@testing-library/jest-dom/extend-expect";
+import { waitFor } from "@testing-library/dom";
 import VocabPage from "./VocabPage";
 import AssetNotFound, {
   MISSING_RESOURCE,
@@ -7,7 +8,6 @@ import AssetNotFound, {
 } from "../AssetNotFound/AssetNotFound";
 import { renderWithRoute } from "../../../services/testUtils";
 import { getVocabularyByUri } from "../../../services/vocabService";
-import { act } from "@testing-library/react";
 import VocabDetails from "../VocabDetails/VocabDetails";
 import { ASSETS_VOCABULARIES_FULL_URL } from "../../../services/routes";
 const { getVocabularyUrl } = jest.requireActual(
@@ -36,21 +36,19 @@ describe("<VocabPage />", () => {
       getVocabularyByUri.mockResolvedValue(null);
     });
 
-    test("it should show error if uri param is missing", async () => {
-      await act(async () => {
-        renderWithRoute(<VocabPage />, ASSETS_VOCABULARIES_FULL_URL);
-      });
+    test("it should show error if uri param is missing", () => {
+      renderWithRoute(<VocabPage />, ASSETS_VOCABULARIES_FULL_URL);
 
       expect(AssetNotFound).toHaveBeenCalledWith({ reason: MISSING_URI }, {});
       expect(getVocabularyByUri).not.toHaveBeenCalled();
     });
 
     test("it should show missing vocab if uri lookup fails", async () => {
-      await act(async () => {
-        renderWithRoute(<VocabPage />, getVocabularyUrl("non-existent"));
-      });
+      renderWithRoute(<VocabPage />, getVocabularyUrl("non-existent"));
 
-      expect(getVocabularyByUri).toHaveBeenCalledWith("non-existent");
+      await waitFor(() =>
+        expect(getVocabularyByUri).toHaveBeenCalledWith("non-existent")
+      );
       expect(AssetNotFound).toHaveBeenCalledWith(
         { reason: MISSING_RESOURCE },
         {}
@@ -68,11 +66,9 @@ describe("<VocabPage />", () => {
     });
 
     test("it should show missing vocab if uri lookup fails", async () => {
-      await act(async () => {
-        renderWithRoute(<VocabPage />, getVocabularyUrl(uri));
-      });
+      renderWithRoute(<VocabPage />, getVocabularyUrl(uri));
 
-      expect(getVocabularyByUri).toHaveBeenCalledWith(uri);
+      await waitFor(() => expect(getVocabularyByUri).toHaveBeenCalledWith(uri));
       expect(AssetNotFound).not.toHaveBeenCalled();
       expect(VocabDetails).toHaveBeenCalledWith({ details: vocabData }, {});
     });


### PR DESCRIPTION
- It's a best practices to avoid wrapping `react render` unnecessarily in `act`. 
- Update queries based on guiding principles [here](https://testing-library.com/docs/queries/about/#priority)